### PR TITLE
Update to Terraform 1.0.11 to avoid a security issue

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-terraform 1.0.2
+terraform 1.0.11


### PR DESCRIPTION
## Overview

This change updates from 1.0.2 of Terraform to 1.0.11 (newest 1.0.x version) to avoid a security issue that is raised when using 1.0.2 on a Mac.